### PR TITLE
Fixed check for mailinglists and conversion into adresses, fixes #4

### DIFF
--- a/protocoldude3.py
+++ b/protocoldude3.py
@@ -249,11 +249,13 @@ class TOP(Protocol):
         self.users = list(set(users))  # remove duplicates
 
     def get_mails(self):
+        mailinglistusers = []
         for user in self.users:
-            if user in LIST_USERS[:][0]:
+            if any(user.lower() in account for account, greeting in LIST_USERS):
                 self.mails.append(user + "@mathphys.stura.uni-heidelberg.de")
-                self.users.remove(user)
-
+                mailinglistusers.append(user)
+        [self.users.remove(user) for user in mailinglistusers]
+        
         result = extract_mails(ldap_search(self.users))
         
         if self.mails:
@@ -271,8 +273,8 @@ class TOP(Protocol):
             msg["To"] = mail
             msg["Subject"] = self.args.mail_subject_prefix+": "+self.title.title_text
 
-            if user in LIST_USERS[:][0]:
-                body = LIST_USERS[LIST_USERS[:][0].index(user)][1] + ",\n\n"
+            if any(user.lower() in account for account, greeting in LIST_USERS):
+                body = [greeting for [account, greeting] in LIST_USERS if account == user.lower()][0] + ",\n\n"
             else:
                 body = "Hallo {},\n\n".format(user)
             body += "Du sollst über irgendwas informiert werden. Im Sitzungsprotokoll steht dazu folgendes:\n\n{}\n\n\nViele Grüße, Dein SPAM-Skript.".format(


### PR DESCRIPTION
Dies sollte Issue #4 lösen. Dies sollte man aber nochmal auf dem Produktivsystem testen, weil ich die Anbindung ans LDAP nicht testen konnte.

Es gab im Code drei Probleme: 

1. Zum einen war dieser Check fehlerhaft: `if user in LIST_USERS[:][0]:` Der Zugriff auf eine Spalte in einer verschachtelten Liste in Python funktioniert so nicht, dies gibt einem momentan nur die erste Zeile zurück, also den ersten Eintrag. Deshalb hat der Check nur bei dem user "fachschaft" geklappt und ansonsten `false` ergeben. Wenn LIST_USERS ein numpy array wäre, könne man mit `[:,0]` darauf zugreifen, aber mit normalen Python lists geht dies nicht. The python way of doing it sieht so aus: `if any(user.lower() in account for account, greeting in LIST_USERS):`

2. bisher war die Überprüfung case sensitive. Jetzt habe ich die Eingabe auf lowercase transformiert, sodass man auch "Fachschaft" oder "InfoStudkom" als Liste eingeben kann und der Dude das ordentlich verarbeitet.

3. In dieser Schleife 
```python 
for user in self.users:
    if user in LIST_USERS[:][0]:
        self.mails.append(user + "@mathphys.stura.uni-heidelberg.de")
        self.users.remove(user)
```
wird über `self.users` iteriert, aber in manchen Fällen `self.users` manipuliert. Das ist böse und erzeugt bugs. Bisher war dies kein Problem, weil der Check aus 1. nicht geklappt hat, aber ich hab das auch gleich mal mit behoben.